### PR TITLE
Fixed the git checkout and cloned repo in the home directory of ec2-user

### DIFF
--- a/terraform-file/development-server-userdata.sh
+++ b/terraform-file/development-server-userdata.sh
@@ -10,6 +10,7 @@ curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compo
 chmod +x /usr/local/bin/docker-compose
 yum install git -y
 yum install java-11-amazon-corretto -y
+cd /home/ec2-user
 git clone https://github.com/cmakkaya/microservices-with-db-on-dev-server.git
 cd microservices-with-db-on-dev-server
-git checkout dev
+git checkout -b dev


### PR DESCRIPTION
# Directory Location and Branch Creation Fix

## Summary
This PR addresses two issues in the repository setup process:
1. Changes the default clone directory to improve visibility
2. Fixes branch creation command to handle non-existent branches

## Changes Made
* Modified clone destination from root to `/home/ec2-user` directory
* Updated git checkout command to include `-b` flag for proper branch creation

## Problem
* Repository was being cloned to root directory, making it less accessible
* `git checkout dev` was failing because the 'dev' branch didn't exist

## Solution
* Changed clone path to `/home/ec2-user` for better visibility and access
* Modified command to `git checkout -b dev` to create and switch to the dev branch

## Testing Done
* Verified successful clone in `/home/ec2-user` directory
* Confirmed proper branch creation and switching with modified command

## Additional Notes
* No breaking changes introduced
* Maintains backward compatibility
* Improves developer experience

Let me know if you need any clarification or have questions about these changes.